### PR TITLE
feat: add real-time agent status tracking and watch mode

### DIFF
--- a/tests/test_commands_list.py
+++ b/tests/test_commands_list.py
@@ -1,0 +1,225 @@
+"""Tests for list command."""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import click.testing
+import pytest
+
+from aifleet.commands.list import display_agents, list
+from aifleet.config import ConfigManager
+from aifleet.state import Agent, StateManager
+from aifleet.tmux import TmuxManager
+
+
+class TestListCommand:
+    """Tests for list command."""
+
+    @pytest.fixture
+    def sample_agents(self):
+        """Create sample agents for testing."""
+        now = datetime.now()
+        return [
+            Agent(
+                branch="feature-1",
+                session="ai_feature-1",
+                agent="claude",
+                batch_id="batch1",
+                created_at=(now - timedelta(hours=2)).isoformat(),
+                worktree="/path/to/worktree1",
+                pid=1234,
+                prompt="Fix the bug",
+            ),
+            Agent(
+                branch="feature-2",
+                session="ai_feature-2",
+                agent="claude",
+                batch_id="batch1",
+                created_at=(now - timedelta(hours=1)).isoformat(),
+                worktree="/path/to/worktree2",
+                pid=5678,
+                prompt="Add new feature",
+            ),
+        ]
+
+    def test_display_agents_with_new_statuses(self, sample_agents, capsys):
+        """Test display_agents shows new status types with colors."""
+        # Mock dependencies
+        config = MagicMock(spec=ConfigManager)
+        config.repo_root = "/test/repo"
+        config.tmux_prefix = "ai_"
+        state = MagicMock(spec=StateManager)
+        state.list_agents.return_value = sample_agents
+        state.reconcile_with_tmux.return_value = []
+
+        tmux_mgr = MagicMock(spec=TmuxManager)
+        tmux_mgr.list_sessions.return_value = [
+            ("ai_feature-1", 1234),
+            ("ai_feature-2", 5678),
+        ]
+
+        # Mock status detection
+        def mock_get_agent_status(branch):
+            if branch == "feature-1":
+                return "ready"
+            elif branch == "feature-2":
+                return "running"
+            return "unknown"
+
+        tmux_mgr.get_agent_status.side_effect = mock_get_agent_status
+
+        # Mock process stats
+        with patch("aifleet.commands.list.get_process_stats") as mock_stats:
+            mock_stats.return_value = (25.5, 1024.0)  # CPU%, Memory MB
+
+            # Display agents
+            display_agents(config, state, tmux_mgr, grouped=False, all=False)
+
+        # Check output
+        captured = capsys.readouterr()
+        output = captured.out
+
+        # Check headers
+        assert "BRANCH" in output
+        assert "STATUS" in output
+
+        # Check that status values are displayed
+        assert "ready" in output
+        assert "running" in output
+
+        # Check summary includes status breakdown
+        assert "Status:" in output
+        assert "ready: 1" in output
+        assert "running: 1" in output
+
+    def test_display_agents_grouped(self, sample_agents, capsys):
+        """Test display_agents with grouping by batch."""
+        # Mock dependencies
+        config = MagicMock(spec=ConfigManager)
+        config.repo_root = "/test/repo"
+        config.tmux_prefix = "ai_"
+        state = MagicMock(spec=StateManager)
+        state.list_agents.return_value = sample_agents
+        state.reconcile_with_tmux.return_value = []
+
+        tmux_mgr = MagicMock(spec=TmuxManager)
+        tmux_mgr.list_sessions.return_value = [
+            ("ai_feature-1", 1234),
+            ("ai_feature-2", 5678),
+        ]
+        tmux_mgr.get_agent_status.return_value = "ready"
+
+        with patch("aifleet.commands.list.get_process_stats", return_value=(0, 0)):
+            display_agents(config, state, tmux_mgr, grouped=True, all=False)
+
+        captured = capsys.readouterr()
+        output = captured.out
+
+        # Check batches are shown
+        assert "batch1" in output
+        assert "Batches: 1" in output
+
+    def test_list_command_normal_mode(self):
+        """Test list command in normal mode."""
+        runner = click.testing.CliRunner()
+
+        with (
+            patch("aifleet.commands.list.ensure_project_config") as mock_config,
+            patch("aifleet.commands.list.StateManager"),
+            patch("aifleet.commands.list.TmuxManager"),
+            patch("aifleet.commands.list.display_agents") as mock_display,
+        ):
+            # Setup mocks
+            config = MagicMock(spec=ConfigManager)
+            config.repo_root = "/test/repo"
+            config.tmux_prefix = "ai_"
+            mock_config.return_value = config
+
+            # Run command
+            result = runner.invoke(list, [])
+
+            # Check it ran successfully
+            assert result.exit_code == 0
+
+            # Check display_agents was called once
+            mock_display.assert_called_once()
+
+    def test_list_command_watch_mode(self):
+        """Test list command in watch mode."""
+        runner = click.testing.CliRunner()
+
+        with (
+            patch("aifleet.commands.list.ensure_project_config") as mock_config,
+            patch("aifleet.commands.list.StateManager"),
+            patch("aifleet.commands.list.TmuxManager"),
+            patch("aifleet.commands.list.display_agents") as mock_display,
+            patch("time.sleep") as mock_sleep,
+        ):
+            # Setup mocks
+            config = MagicMock(spec=ConfigManager)
+            config.repo_root = "/test/repo"
+            config.tmux_prefix = "ai_"
+            mock_config.return_value = config
+
+            # Simulate KeyboardInterrupt after 2 iterations
+            mock_sleep.side_effect = [None, KeyboardInterrupt]
+
+            # Run command with --watch
+            result = runner.invoke(list, ["--watch"])
+
+            # Check it exited with code 0 (handled KeyboardInterrupt)
+            assert result.exit_code == 0
+
+            # Check display_agents was called multiple times
+            assert mock_display.call_count == 2
+
+            # Check output mentions exiting watch mode
+            assert "Exiting watch mode" in result.output
+
+    def test_list_command_all_statuses(self, sample_agents):
+        """Test that all status types are handled correctly."""
+        statuses = ["ready", "running", "idle", "dead", "unknown"]
+
+        config = MagicMock(spec=ConfigManager)
+        config.repo_root = "/test/repo"
+        config.tmux_prefix = "ai_"
+        state = MagicMock(spec=StateManager)
+        tmux_mgr = MagicMock(spec=TmuxManager)
+
+        # Create one agent for each status
+        agents = []
+        for i, status in enumerate(statuses):
+            agent = Agent(
+                branch=f"feature-{status}",
+                session=f"ai_feature-{status}",
+                agent="claude",
+                batch_id="batch1",
+                created_at=datetime.now().isoformat(),
+                worktree=f"/path/to/worktree{i}",
+                pid=1000 + i,
+            )
+            agents.append(agent)
+
+        state.list_agents.return_value = agents
+        state.reconcile_with_tmux.return_value = []
+        tmux_mgr.list_sessions.return_value = [
+            (a.session, a.pid) for a in agents if a.branch != "feature-dead"
+        ]
+
+        # Mock status detection to return each status type
+        def mock_get_status(branch):
+            for status in statuses:
+                if f"feature-{status}" in branch:
+                    return status
+            return "unknown"
+
+        tmux_mgr.get_agent_status.side_effect = mock_get_status
+
+        with patch("aifleet.commands.list.get_process_stats", return_value=(0, 0)):
+            with patch("click.echo") as mock_echo:
+                display_agents(config, state, tmux_mgr, grouped=False, all=False)
+
+                # Verify all statuses appear in output
+                output = " ".join(str(call) for call in mock_echo.call_args_list)
+                for status in statuses:
+                    assert status in output

--- a/tests/test_tmux.py
+++ b/tests/test_tmux.py
@@ -1,0 +1,143 @@
+"""Tests for tmux module."""
+
+from unittest.mock import MagicMock, patch
+
+from aifleet.tmux import TmuxManager
+
+
+class TestTmuxManager:
+    """Tests for TmuxManager class."""
+
+    def test_get_pane_content_success(self):
+        """Test successful pane content capture."""
+        tmux_mgr = TmuxManager()
+
+        # Mock subprocess.run to return pane content
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Human: help me with this code\n$"
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            content = tmux_mgr.get_pane_content("feature-branch")
+
+            # Verify the command was called correctly
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args == ["tmux", "capture-pane", "-t", "ai_feature-branch", "-p"]
+
+            # Verify content was returned
+            assert content == "Human: help me with this code\n$"
+
+    def test_get_pane_content_failure(self):
+        """Test pane content capture failure."""
+        tmux_mgr = TmuxManager()
+
+        # Mock subprocess.run to fail
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+
+        with patch("subprocess.run", return_value=mock_result):
+            content = tmux_mgr.get_pane_content("feature-branch")
+            assert content is None
+
+    def test_get_pane_content_exception(self):
+        """Test pane content capture with exception."""
+        tmux_mgr = TmuxManager()
+
+        # Mock subprocess.run to raise exception
+        with patch("subprocess.run", side_effect=Exception("tmux error")):
+            content = tmux_mgr.get_pane_content("feature-branch")
+            assert content is None
+
+    def test_get_agent_status_dead(self, mock_tmux_server):
+        """Test agent status when session doesn't exist."""
+        tmux_mgr = TmuxManager()
+        tmux_mgr.server = mock_tmux_server
+
+        # Session doesn't exist
+        mock_tmux_server.find_where.return_value = None
+
+        status = tmux_mgr.get_agent_status("feature-branch")
+        assert status == "dead"
+
+    def test_get_agent_status_unknown(self, mock_tmux_server):
+        """Test agent status when pane content can't be captured."""
+        tmux_mgr = TmuxManager()
+        tmux_mgr.server = mock_tmux_server
+
+        # Session exists
+        mock_tmux_server.find_where.return_value = MagicMock()
+
+        # But pane content capture fails
+        with patch.object(tmux_mgr, "get_pane_content", return_value=None):
+            status = tmux_mgr.get_agent_status("feature-branch")
+            assert status == "unknown"
+
+    def test_get_agent_status_ready(self, mock_tmux_server):
+        """Test agent status when waiting for input."""
+        tmux_mgr = TmuxManager()
+        tmux_mgr.server = mock_tmux_server
+
+        # Session exists
+        mock_tmux_server.find_where.return_value = MagicMock()
+
+        # Test various ready states
+        ready_contents = [
+            "Human: help me\n$",
+            "some output\n>",
+            "prompt:",
+            "Human: what's next?",
+            "/path/to/project $ ",
+        ]
+
+        for content in ready_contents:
+            with patch.object(tmux_mgr, "get_pane_content", return_value=content):
+                status = tmux_mgr.get_agent_status("feature-branch")
+                assert status == "ready", f"Failed for content: {content}"
+
+    def test_get_agent_status_running(self, mock_tmux_server):
+        """Test agent status when Claude is running."""
+        tmux_mgr = TmuxManager()
+        tmux_mgr.server = mock_tmux_server
+
+        # Session exists
+        mock_tmux_server.find_where.return_value = MagicMock()
+
+        # Test various running states
+        running_contents = [
+            "I'll help you with that code\nesc to interrupt",
+            "Thinking about the problem...",
+            "Let me analyze this",
+            "I'm going to check the files",
+            "Looking at the codebase",
+            "Searching for the issue",
+            "Processing your request",
+            "Analyzing the error",
+        ]
+
+        for content in running_contents:
+            with patch.object(tmux_mgr, "get_pane_content", return_value=content):
+                status = tmux_mgr.get_agent_status("feature-branch")
+                assert status == "running", f"Failed for content: {content}"
+
+    def test_get_agent_status_idle(self, mock_tmux_server):
+        """Test agent status when idle."""
+        tmux_mgr = TmuxManager()
+        tmux_mgr.server = mock_tmux_server
+
+        # Session exists
+        mock_tmux_server.find_where.return_value = MagicMock()
+
+        # Test idle state - has content but not running or ready
+        idle_content = (
+            "Some previous output that doesn't match any patterns\nNo clear prompt here"
+        )
+
+        with patch.object(tmux_mgr, "get_pane_content", return_value=idle_content):
+            status = tmux_mgr.get_agent_status("feature-branch")
+            assert status == "idle"
+
+        # Test idle with minimal content
+        with patch.object(tmux_mgr, "get_pane_content", return_value="short"):
+            status = tmux_mgr.get_agent_status("feature-branch")
+            assert status == "idle"


### PR DESCRIPTION
## Summary
- Adds real-time status detection for AI agents (ready, running, idle, dead, unknown)
- Implements watch mode (-w/--watch) for fleet list command with automatic refresh
- Enhances visibility into what agents are currently doing

## Implementation Details

### Status Detection
Added two new methods to TmuxManager:
- `get_pane_content()`: Captures current tmux pane content
- `get_agent_status()`: Analyzes pane content to determine agent status

Status types:
- **ready** (green): Agent is waiting for input
- **running** (yellow): Agent is processing/thinking
- **idle** (blue): No recent activity
- **dead** (red): Session doesn't exist
- **unknown** (gray): Can't determine status

### Watch Mode
- Added `--watch`/`-w` flag to fleet list command
- Refreshes display every second with current timestamp
- Clear screen between updates for clean display
- Exit with Ctrl+C

### Tests
- Comprehensive test coverage for new functionality
- Tests for all status types and edge cases
- Tests for watch mode behavior

## Test plan
- [x] Run all existing tests - all passing
- [x] Run linter - no issues
- [x] Test status detection manually with real agents
- [x] Test watch mode with multiple agents
- [x] Verify color coding displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)