### PR TITLE
Fix: Increase name truncation limits in fleet list command

### DIFF
--- a/src/aifleet/commands/list.py
+++ b/src/aifleet/commands/list.py
@@ -134,8 +134,8 @@ def create_agents_table(
         status_text = Text(str(data["status"]), style=status_color)
 
         table.add_row(
-            str(data["branch"])[:25],
-            str(data["batch_id"])[:15],
+            str(data["branch"])[:50],
+            str(data["batch_id"])[:30],
             str(data["agent"]),
             status_text,
             f"{float(data['cpu']):.1f}",


### PR DESCRIPTION
## Summary
- Increased branch name truncation from 25 to 50 characters
- Increased batch ID truncation from 15 to 30 characters
- Fixes issue where long session names get cut off in `fleet list` output

## Problem
When creating sessions with long names like `new-issue-bla-bla-bla-bla-bla-bla-bla`, the names were being truncated too aggressively in the list view, making it difficult to identify sessions.

## Solution
Updated the truncation limits in `src/aifleet/commands/list.py` to allow longer names while maintaining UI readability.

## Test plan
- [x] Create a session with a long name
- [x] Run `fleet list` and verify the full name is visible
- [x] Ensure table formatting remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)